### PR TITLE
Make OpenAI API key configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ La página incluye una sección que utiliza la API de OpenAI para responder preg
 Para habilitarla debes proporcionar tu clave de API de alguna de estas formas:
 
 - **Entorno Node**: define la variable de entorno `OPENAI_API_KEY` antes de ejecutar el proyecto.
-- **En el navegador**: inyecta la clave en el HTML mediante una etiqueta `<meta name="openai-api-key" content="TU_CLAVE">` o un `input` oculto con `name="openai-api-key"` (o `id="openai-api-key"`).
+- **En el navegador**: inyecta la clave en el HTML mediante una etiqueta `<meta name="openai-api-key" content="TU_CLAVE">` o un `input` oculto con `name="openai-api-key"` (o `id="openai-api-key"`). Usa siempre HTTPS o `localhost` si cargas la clave desde el DOM para evitar que se filtre en tránsito.
+
+**Recomendaciones de seguridad**
+
+- No publiques la clave de OpenAI en un sitio público: si necesitas exponerla en el navegador hazlo solo en HTTPS o `localhost` y evalúa usar un backend proxy que firme las solicitudes.
+- Evita guardar la clave en localStorage u otros medios persistentes en el cliente.
+- Comprueba que la variable `OPENAI_API_KEY` no quede registrada en logs o herramientas de build.
 
 ## Cómo contribuir
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ Tecnologías y herramientas utilizadas en el proyecto, por ejemplo:
 ## Consulta Git con IA
 
 La página incluye una sección que utiliza la API de OpenAI para responder preguntas sobre Git.
-Para habilitarla debes indicar tu clave de API en el archivo `resources/js/index.js` asignándola a `OPENAI_API_KEY`.
+Para habilitarla debes proporcionar tu clave de API de alguna de estas formas:
+
+- **Entorno Node**: define la variable de entorno `OPENAI_API_KEY` antes de ejecutar el proyecto.
+- **En el navegador**: inyecta la clave en el HTML mediante una etiqueta `<meta name="openai-api-key" content="TU_CLAVE">` o un `input` oculto con `name="openai-api-key"` (o `id="openai-api-key"`).
 
 ## Cómo contribuir
 

--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -137,9 +137,34 @@ function copyCode(elementId, button) {
   }
 }
 
-const OPENAI_API_KEY = '';
+function getOpenAIApiKey() {
+  // Para entornos Node (por ejemplo durante la construcción o pruebas)
+  if (typeof process !== "undefined" && process?.env?.OPENAI_API_KEY) {
+    return process.env.OPENAI_API_KEY;
+  }
+
+  // Para la web: se puede inyectar mediante una etiqueta <meta>
+  const metaToken = document.querySelector('meta[name="openai-api-key"]');
+  if (metaToken?.content) {
+    return metaToken.content;
+  }
+
+  // O mediante un input oculto (útil si se carga dinámicamente)
+  const hiddenInput = document.querySelector('input[type="hidden"][name="openai-api-key"], input[type="hidden"]#openai-api-key');
+  if (hiddenInput?.value) {
+    return hiddenInput.value;
+  }
+
+  return "";
+}
+
+const OPENAI_API_KEY = getOpenAIApiKey();
 
 async function askOpenAI(question) {
+  if (!OPENAI_API_KEY) {
+    throw new Error('Falta la clave de API de OpenAI.');
+  }
+
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {

--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -140,30 +140,52 @@ function copyCode(elementId, button) {
 function getOpenAIApiKey() {
   // Para entornos Node (por ejemplo durante la construcción o pruebas)
   if (typeof process !== "undefined" && process?.env?.OPENAI_API_KEY) {
-    return process.env.OPENAI_API_KEY;
+    return { key: String(process.env.OPENAI_API_KEY).trim(), source: "env" };
   }
 
-  // Para la web: se puede inyectar mediante una etiqueta <meta>
-  const metaToken = document.querySelector('meta[name="openai-api-key"]');
-  if (metaToken?.content) {
-    return metaToken.content;
+  if (typeof document !== "undefined") {
+    // Para la web: se puede inyectar mediante una etiqueta <meta>
+    const metaToken = document.querySelector('meta[name="openai-api-key"]');
+    if (metaToken?.content) {
+      return { key: metaToken.content.trim(), source: "dom" };
+    }
+
+    // O mediante un input oculto (útil si se carga dinámicamente)
+    const hiddenInput = document.querySelector('input[type="hidden"][name="openai-api-key"], input[type="hidden"]#openai-api-key');
+    if (hiddenInput?.value) {
+      return { key: hiddenInput.value.trim(), source: "dom" };
+    }
   }
 
-  // O mediante un input oculto (útil si se carga dinámicamente)
-  const hiddenInput = document.querySelector('input[type="hidden"][name="openai-api-key"], input[type="hidden"]#openai-api-key');
-  if (hiddenInput?.value) {
-    return hiddenInput.value;
-  }
-
-  return "";
+  return { key: "", source: "none" };
 }
 
-const OPENAI_API_KEY = getOpenAIApiKey();
+function assertOpenAISafety(apiKeySource) {
+  // Cuando se expone la clave desde el DOM, impedir su uso en contextos no seguros
+  if (apiKeySource === "dom" && typeof window !== "undefined") {
+    const isLocalhost = ["localhost", "127.0.0.1", "::1"].includes(window.location.hostname);
+    const isSecure = window.isSecureContext === true;
+
+    if (!isSecure && !isLocalhost) {
+      throw new Error(
+        "La clave de OpenAI solo debe inyectarse en contextos seguros (HTTPS o localhost). Considera usar un backend proxy."
+      );
+    }
+
+    console.warn(
+      "Advertencia: la clave de OpenAI está disponible en el cliente. Evita exponerla en producción; usa un servicio backend para firmar las solicitudes."
+    );
+  }
+}
+
+const { key: OPENAI_API_KEY, source: OPENAI_API_KEY_SOURCE } = getOpenAIApiKey();
 
 async function askOpenAI(question) {
   if (!OPENAI_API_KEY) {
     throw new Error('Falta la clave de API de OpenAI.');
   }
+
+  assertOpenAISafety(OPENAI_API_KEY_SOURCE);
 
   const response = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',


### PR DESCRIPTION
## Summary
- load the OpenAI API key from environment variables, meta tags, or hidden inputs instead of a hardcoded value
- guard requests when the key is missing
- document how to provide the API key in Node and browser contexts

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957fe5c29dc832e94ceddff0336f534)